### PR TITLE
feat(ci): 添加 GHCR 发布并同步镜像标签规则

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -31,6 +31,14 @@ on:
         description: SnowLuma source repository in `owner/repo` form. Leave blank to fall back to the checked-in SnowLuma.Framework.tar.gz.
         required: false
         default: "SnowLuma/SnowLuma"
+      ghcr_image:
+        description: 'GHCR image name (e.g. ghcr.io/snowluma/snowluma). Leave empty to skip GHCR.'
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+  packages: write
 
 jobs:
   resolve:
@@ -113,12 +121,21 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Login to GHCR
+        if: ${{ inputs.push && inputs.ghcr_image != '' }}
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build image
         env:
           IMAGE: ${{ inputs.image }}
           TAG: ${{ inputs.tag }}
           PUSH: ${{ inputs.push }}
           PLATFORM: ${{ matrix.platform }}
+          GHCR_IMAGE: ${{ inputs.ghcr_image }}
         run: |
           set -eu
           if [ -z "${IMAGE}" ]; then
@@ -145,6 +162,24 @@ jobs:
             fi
             mkdir -p digests
             touch "digests/${digest#sha256:}"
+
+            if [ -n "${GHCR_IMAGE}" ]; then
+              docker buildx build \
+                --platform "${PLATFORM}" \
+                --tag "${GHCR_IMAGE}" \
+                --file ./Dockerfile \
+                --output "type=image,push-by-digest=true,name-canonical=true,push=true" \
+                --metadata-file metadata-ghcr.json \
+                .
+              ghcr_digest="$(jq -r '."containerimage.digest"' metadata-ghcr.json)"
+              if [ -z "${ghcr_digest}" ] || [ "${ghcr_digest}" = "null" ]; then
+                echo "Unable to resolve pushed GHCR image digest" >&2
+                cat metadata-ghcr.json >&2
+                exit 1
+              fi
+              mkdir -p digests-ghcr
+              touch "digests-ghcr/${ghcr_digest#sha256:}"
+            fi
           else
             docker buildx build \
               --platform "${PLATFORM}" \
@@ -163,9 +198,20 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
+      - name: Upload GHCR digest
+        if: ${{ inputs.push && inputs.ghcr_image != '' }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: ghcr-digest-${{ matrix.arch }}
+          path: digests-ghcr/*
+          if-no-files-found: error
+          retention-days: 1
+
       - name: Docker logout
         if: ${{ always() && inputs.push }}
-        run: docker logout || true
+        run: |
+          docker logout || true
+          docker logout ghcr.io || true
 
   merge:
     if: ${{ inputs.push }}
@@ -184,11 +230,27 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Login to GHCR
+        if: ${{ inputs.ghcr_image != '' }}
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Download Docker image digests
         uses: actions/download-artifact@v7
         with:
           pattern: docker-digest-*
           path: digests
+          merge-multiple: true
+
+      - name: Download GHCR digests
+        if: ${{ inputs.ghcr_image != '' }}
+        uses: actions/download-artifact@v7
+        with:
+          pattern: ghcr-digest-*
+          path: digests-ghcr
           merge-multiple: true
 
       - name: Create Docker manifest
@@ -214,6 +276,32 @@ jobs:
           docker buildx imagetools create "${tags[@]}" "${refs[@]}"
           docker buildx imagetools inspect "${image}:${tag}"
 
+      - name: Create GHCR manifest
+        if: ${{ inputs.ghcr_image != '' }}
+        run: |
+          set -euo pipefail
+          ghcr_image="${{ inputs.ghcr_image }}"
+          tag="${{ inputs.tag }}"
+          cd digests-ghcr
+          shopt -s nullglob
+          ghcr_digest_files=(*)
+          if [ "${#ghcr_digest_files[@]}" -eq 0 ]; then
+            echo "No GHCR digests were produced" >&2
+            exit 1
+          fi
+          ghcr_refs=()
+          for digest in "${ghcr_digest_files[@]}"; do
+            ghcr_refs+=("${ghcr_image}@sha256:${digest}")
+          done
+          ghcr_tags=(--tag "${ghcr_image}:${tag}")
+          if [ "${tag}" != "latest" ]; then
+            ghcr_tags+=(--tag "${ghcr_image}:latest")
+          fi
+          docker buildx imagetools create "${ghcr_tags[@]}" "${ghcr_refs[@]}"
+          docker buildx imagetools inspect "${ghcr_image}:${tag}"
+
       - name: Docker logout
         if: always()
-        run: docker logout || true
+        run: |
+          docker logout || true
+          docker logout ghcr.io || true


### PR DESCRIPTION
新增可选 `ghcr_image` 输入，让每个架构的镜像同时推送到 Docker Hub 和 GHCR，再分别合并多架构 manifest。留空时保留仅发布 Docker Hub 的行为。

GHCR 与 Docker Hub 使用相同的 `also_latest` / `sha_tag` 规则：例如 dev 构建传入 `also_latest=false` 和 `sha_tag=dev-<commit>` 时，只发布 dev 与对应提交标签，不覆盖稳定版 latest。保留现有 artifact 下载、dev 并发控制和 Docker Hub 旧标签清理流程。

GHCR 使用 `GITHUB_TOKEN` 的 `packages: write` 权限；README 补充首次发布后的 Public 可见性设置，以及已有 package 的 Actions 写入权限要求。

验证：
- actionlint 1.7.12 工作流校验通过。
- 9 段 Bash 脚本语法检查通过。
- 16 项 manifest 标签/架构组合、3 项构建分支、2 项空 digest 拒绝检查通过；实际执行工作流脚本，模拟 Docker/jq。
- 未执行真实镜像构建或 registry 推送。

主仓库调用端：https://github.com/SnowLuma/SnowLuma/pull/78 ，应在本 PR 合并后合并。
