### PR TITLE
Fix: Install iproute2 to provide the `ss` command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
       fonts-wqy-zenhei \
       git \
       gnutls-bin \
+      iproute2 \
       libasound2 \
       libatspi2.0-0 \
       libgbm1 \


### PR DESCRIPTION
我是SnowLuma的容器化用户，发现容器镜像内缺少`ss`命令导致一些功能失效，因此提出PR来修复。

我注意到在SnowLuma容器中成功登录QQ后，控制台的“进程注入”处会正确显示“qq已在线”：
<img width="1920" height="1020" alt="114b07209f64f837bd16bf2f069ef5bd" src="https://github.com/user-attachments/assets/829ba4cc-8f56-4bae-a70e-5a18684c99ee" />

此时点击“探测登录”，却会错误地显示“未检测到登录信息”：
<img width="1920" height="1020" alt="f6c2c4a1c681e1755e8aa0f04593e3b5" src="https://github.com/user-attachments/assets/3d329271-1319-48aa-8e38-47f660cb0ff6" />

在阅读了代码后，我发现探测登录功能是依赖Linux `ss`命令实现的，而镜像中缺少`ss`命令。为了安装`ss`命令，我在Dockerfile的apt安装脚本处添加了`iproute2`包来提供`ss`命令。

安装后测试探测登录功能正常：
<img width="1920" height="1020" alt="e7cf12be91babb11e7632280eed69086" src="https://github.com/user-attachments/assets/956a6087-366f-4da1-a9de-2e50bc5d984d" />
