### PR TITLE
feat(start.sh): 在持久化存储卷中，复用 / 创建 machine-id 避免登录认证失效

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -36,6 +36,20 @@ mkdir -p \
   /app/.local/share \
   /etc/supervisor/conf.d
 
+ensure_machine_id() {
+  local persistent="${SNOWLUMA_DATA}/config/machine-id"
+
+  mkdir -p "$(dirname "$persistent")" || { echo "FATAL: cannot create machine-id persistent directory" >&2; exit 1; }
+
+  if [ ! -f "$persistent" ]; then
+    dbus-uuidgen > "$persistent" || { echo "FATAL: dbus-uuidgen failed to generate machine-id" >&2; exit 1; }
+  fi
+
+  ln -sf "$persistent" /etc/machine-id || { echo "FATAL: cannot symlink machine-id" >&2; exit 1; }
+}
+
+ensure_machine_id
+
 groupmod -o -g "${SNOWLUMA_GID}" snowluma
 usermod -o -u "${SNOWLUMA_UID}" -g "${SNOWLUMA_GID}" snowluma
 


### PR DESCRIPTION
## 概述
WSL 和 macOS 不像典型 Linux 提供一个稳定的 /etc/machine-id 可靠来源。复用已有的持久化路径传递 machine-id 而不选择创建新的存储卷，可以解决跨平台问题，同时保证容器重建后 QQ 自动登录不会失效。

### 自动创建 / 传递 `machine-id` 的机制

1.  **检查持久化文件**：函数首先检查 `${SNOWLUMA_DATA}/config/machine-id` 这个文件是否存在（`SNOWLUMA_DATA` 默认路径为 `/app/snowluma-data`）。
2.  **自动生成与持久化**：如果该文件**不存在**，脚本会调用 `dbus-uuidgen` 命令生成一个新的通用唯一标识符（UUID），并将其**写入**到 `${SNOWLUMA_DATA}/config/machine-id` 文件中。这样就完成了首次创建。
3.  **创建符号链接**：最后，脚本会将容器内的 `/etc/machine-id` 创建为一个**符号链接**，指向这个持久化文件 (`ln -sf "$persistent" /etc/machine-id`)。
