### PR TITLE
fix: 修复x11vnc连接卡死问题

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -197,7 +197,7 @@ XVFB_PID=$!
 wait_for_xvfb
 
 fluxbox &
-x11vnc -display "${DISPLAY}" -noxrecord -noxfixes -noxdamage -forever -rfbauth /root/.vnc/passwd &
+x11vnc -display "${DISPLAY}" -noxrecord -noxfixes -noxdamage -forever -threads -rfbauth /root/.vnc/passwd &
 X11VNC_PID=$!
 sleep 0.5
 if ! kill -0 "${X11VNC_PID}" 2>/dev/null; then


### PR DESCRIPTION
## 问题描述

在部分容器环境中，noVNC 页面可以正常加载，但无法完成 VNC 连接，具体表现为：

- x11vnc 长时间占用接近一个 CPU 核心
- 5900 端口能够建立 TCP 连接，但不返回 RFB 协议头
- noVNC 不断出现 WebSocket 握手或连接失败

原因是 x11vnc 在单线程模式下可能因持续轮询 Xvfb 屏幕而阻塞 RFB 网络请求处理。

## 修改内容

- 为 x11vnc 启动命令增加 `-threads` 参数

## 验证结果

启用 `-threads` 后：

- 5900 端口能够立即返回 `RFB 003.008`
- noVNC 可以通过 6081 端口正常连接
- x11vnc CPU 占用从约 96% 降至 1% 以下